### PR TITLE
Add Job routes

### DIFF
--- a/src/backend/controllers/jobs.js
+++ b/src/backend/controllers/jobs.js
@@ -81,11 +81,11 @@ const listOfJob = [
   },
 ];
 
-module.exports.listJobs = async (req, res) => {
+module.exports.listJobs = (req, res) => {
   return res.json(listOfJob);
 };
 
-module.exports.getJobById = async (req, res) => {
+module.exports.getJobById = (req, res) => {
   const { jobId } = req.params;
   if (!jobId) {
     return res.status(400).json({
@@ -99,4 +99,15 @@ module.exports.getJobById = async (req, res) => {
     });
   }
   return res.status(200).json(job);
+};
+
+module.exports.createJob = (req, res) => {
+  const { title, company, location, jobType, date } = req.body;
+  if (!title || !company || !location || !jobType || !date) {
+    return res.status(400).json({ error: 'Required arguments not sent' });
+  }
+  const job = { title, company, location, jobType, date };
+
+  listOfJob.push(job);
+  res.json(job);
 };

--- a/src/backend/controllers/jobs.js
+++ b/src/backend/controllers/jobs.js
@@ -1,0 +1,86 @@
+const listOfJob = [
+  {
+    id: '1',
+    title: 'Senior backend developer',
+    company: 'Google.inc',
+    location: 'Addison',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '2',
+    title: 'Senior backend developer',
+    company: 'Google.inc',
+    location: 'Berkeley County',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '3',
+    title: 'Senior backend developer',
+    company: 'Google.inc',
+    location: 'Cambridge',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '4',
+    title: 'Senior backend developer',
+    company: 'Google.inc',
+    location: 'Chandler',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '5',
+    title: 'Senior backend developer',
+    company: 'Google.inc',
+    location: 'Clarksville',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '6',
+    title: 'Senior backend developer',
+    company: 'Google.inc',
+    location: 'Detroit',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '7',
+    title: 'Senior backend developer',
+    company: 'Google.inc',
+    location: 'Dallas',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '8',
+    title: 'Senior backend developer',
+    company: 'Facebook',
+    location: 'Salt Lake City',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '9',
+    title: 'Senior backend developer',
+    company: 'Netflix',
+    location: 'Sunnyvale',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+  {
+    id: '10',
+    title: 'Senior backend developer',
+    company: 'Amazon',
+    location: 'Washington D.C.',
+    jobType: 'Full-time',
+    date: '20, Sept 2020',
+  },
+];
+
+module.exports.listJobs = async (req, res) => {
+  return res.json(listOfJob);
+};

--- a/src/backend/controllers/jobs.js
+++ b/src/backend/controllers/jobs.js
@@ -84,3 +84,19 @@ const listOfJob = [
 module.exports.listJobs = async (req, res) => {
   return res.json(listOfJob);
 };
+
+module.exports.getJobById = async (req, res) => {
+  const { jobId } = req.params;
+  if (!jobId) {
+    return res.status(400).json({
+      error: 'Job id parameter required',
+    });
+  }
+  const job = listOfJob.find((job) => job.id === jobId);
+  if (!job) {
+    return res.status(404).json({
+      error: 'Job not found',
+    });
+  }
+  return res.status(200).json(job);
+};

--- a/src/backend/controllers/jobs.js
+++ b/src/backend/controllers/jobs.js
@@ -111,3 +111,25 @@ module.exports.createJob = (req, res) => {
   listOfJob.push(job);
   res.json(job);
 };
+
+module.exports.editJobById = (req, res) => {
+  const { jobId } = req.params;
+  const { title, company, location, jobType, date } = req.body;
+  if (!jobId) {
+    return res.status(400).json({
+      error: 'Job id parameter required',
+    });
+  }
+  const job = listOfJob.find((job) => job.id === jobId);
+  if (!job) {
+    return res.status(404).json({
+      error: 'Job not found',
+    });
+  }
+  job.title = title;
+  job.company = company;
+  job.location = location;
+  job.jobType = jobType;
+  job.date = date;
+  res.json(job);
+};

--- a/src/backend/main.js
+++ b/src/backend/main.js
@@ -2,19 +2,16 @@ const express = require('express');
 const app = express();
 const path = require('path');
 const port = process.env.APP_PORT || 3000;
+const apiRouter = require('./routes');
 
-app.use('/static', express.static(path.join(`${__dirname}/public`)))
+app.use('/static', express.static(path.join(`${__dirname}/public`)));
+
+app.use('/api', apiRouter);
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(`${__dirname}/public/index.html`));
-})
-
-app.get('/api', (req, res) => {
-  res.status(200).json({
-    message: "hello, im api endpoint"
-  });
 });
 
 app.listen(port, () => {
-  console.log(`Backend listening at http://localhost:${port}`)
-})
+  console.log(`Backend listening at http://localhost:${port}`);
+});

--- a/src/backend/main.js
+++ b/src/backend/main.js
@@ -6,6 +6,8 @@ const apiRouter = require('./routes');
 
 app.use('/static', express.static(path.join(`${__dirname}/public`)));
 
+app.use(express.json());
+
 app.use('/api', apiRouter);
 
 app.get('/', (req, res) => {

--- a/src/backend/routes/index.js
+++ b/src/backend/routes/index.js
@@ -1,0 +1,14 @@
+const { Router } = require('express');
+const jobsRouter = require('./jobs');
+
+const apiRouter = Router();
+
+apiRouter.use('/jobs', jobsRouter);
+
+apiRouter.get('/', (req, res) => {
+  res.status(200).json({
+    message: 'hello, im api endpoint',
+  });
+});
+
+module.exports = apiRouter;

--- a/src/backend/routes/jobs.js
+++ b/src/backend/routes/jobs.js
@@ -4,6 +4,7 @@ const jobsController = require('../controllers/jobs');
 const jobsRouter = Router();
 
 jobsRouter.get('/:jobId', jobsController.getJobById);
+jobsRouter.post('/', jobsController.createJob);
 jobsRouter.get('/', jobsController.listJobs);
 
 module.exports = jobsRouter;

--- a/src/backend/routes/jobs.js
+++ b/src/backend/routes/jobs.js
@@ -1,0 +1,8 @@
+const { Router } = require('express');
+const jobsController = require('../controllers/jobs');
+
+const jobsRouter = Router();
+
+jobsRouter.get('/', jobsController.listJobs);
+
+module.exports = jobsRouter;

--- a/src/backend/routes/jobs.js
+++ b/src/backend/routes/jobs.js
@@ -3,6 +3,7 @@ const jobsController = require('../controllers/jobs');
 
 const jobsRouter = Router();
 
+jobsRouter.get('/:jobId', jobsController.getJobById);
 jobsRouter.get('/', jobsController.listJobs);
 
 module.exports = jobsRouter;

--- a/src/backend/routes/jobs.js
+++ b/src/backend/routes/jobs.js
@@ -5,6 +5,7 @@ const jobsRouter = Router();
 
 jobsRouter.get('/:jobId', jobsController.getJobById);
 jobsRouter.post('/', jobsController.createJob);
+jobsRouter.patch('/:jobId', jobsController.editJobById);
 jobsRouter.get('/', jobsController.listJobs);
 
 module.exports = jobsRouter;


### PR DESCRIPTION
## What does this PR do?
Adds routes and controllers for Creating, Reading, and Updating jobs.
For now, just using the in-memory list, but we can adjust it to use mongo or other databases in the future.

### What routes are available?
- **get /api/jobs/:jobId**: Get job by Id
- **post /api/jobs/**: Create new Job
- **patch /api/jobs/:jobId**: Update Job by Id
- **get /api/jobs/**: Get all jobs
