### PR TITLE
Private Routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ render(
     <Route path="/jobs" component={JobsPage} exact />
     <Route path="/apply" component={ApplyPage} />
     <Route path="/" component={JobsPage} exact />
-    <Route path="/admin" component={AdminPanel} exact />
+    <PrivateRoute path="/admin" component={AdminPanel} admin={false} exact />
     <PrivateRoute path="/applicants" component={ApplicantsPage} exact />
   </Router>,
   document.getElementById("root-app")

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "./styles/global.css";
 import AdminPanel from "./pages/admin.page";
 import ApplicantsPage from "./pages/applicants.page";
+import PrivateRoute from "./routing/PrivateRoute";
 
 render(
   <Router>
@@ -18,7 +19,7 @@ render(
     <Route path="/apply" component={ApplyPage} />
     <Route path="/" component={JobsPage} exact />
     <Route path="/admin" component={AdminPanel} exact />
-    <Route path="/applicants" component={ApplicantsPage} exact />
+    <PrivateRoute path="/applicants" component={ApplicantsPage} exact />
   </Router>,
   document.getElementById("root-app")
 );

--- a/src/routing/PrivateRoute.js
+++ b/src/routing/PrivateRoute.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Redirect, Route } from "react-router-dom";
+
+const PrivateRoute = ({ component: Component, ...rest }) => (
+  <Route
+    {...rest}
+    render={(props) =>
+      localStorage.getItem("token") ? (
+        <Component {...props} />
+      ) : (
+        <Redirect to="/login" />
+      )
+    }
+  />
+);
+
+export default PrivateRoute;

--- a/src/routing/PrivateRoute.js
+++ b/src/routing/PrivateRoute.js
@@ -1,17 +1,22 @@
 import React from "react";
 import { Redirect, Route } from "react-router-dom";
+import AdminPanel from "../pages/admin.page";
 
-const PrivateRoute = ({ component: Component, ...rest }) => (
-  <Route
-    {...rest}
-    render={(props) =>
-      localStorage.getItem("token") ? (
-        <Component {...props} />
-      ) : (
-        <Redirect to="/login" />
-      )
+const PrivateRoute = ({ component: Component, ...rest }) => {
+  console.log(rest);
+
+  if (localStorage.getItem("token")) {
+    if (rest.path === "/admin") {
+      if (rest.admin) {
+        return <Route {...rest} component={AdminPanel} exact />;
+      } else {
+        return <Route {...rest} render={(props) => <Redirect to="/jobs" />} />;
+      }
+    } else {
+      return <Route {...rest} render={(props) => <Component {...rest} />} />;
     }
-  />
-);
-
+  } else {
+    return <Route {...rest} render={(props) => <Redirect to="/login" />} />;
+  }
+};
 export default PrivateRoute;


### PR DESCRIPTION
## ISSUE #18 

Aim was to create a hoc file to check for token and admin but the hoc routing does not work in react router v4+. I have added the below link as reference 

https://medium.com/today-i-learned-chai/protect-route-in-react-router-using-hoc-got-dispatching-infinity-loop-59999a2d7c12 

So I created Privates route with the new approach mentioned in the article. Now the user can only view protected routes when they have a token and user can only view admin panel if their isAdmin prop is set to true

**Please check the PR and comment for changes** 